### PR TITLE
Switch to debian

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,10 +1,8 @@
 FROM webdevops/php-dev:alpine-php7
 
-# install mhsendmail and configure it to use mailhog
-RUN apk add --no-cache musl-dev go nano curl
-RUN go get github.com/mailhog/mhsendmail
-RUN cp /root/go/bin/mhsendmail /usr/bin/mhsendmail
-RUN echo 'sendmail_path = /usr/bin/mhsendmail --smtp-addr mail:1025' > /opt/docker/etc/php/php.ini
+# configure postfix to use mailhog
+RUN apk add --no-cache nano curl
+RUN postconf -e "relayhost = mail:1025"
 
 # install wp cli
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/php:alpine-php7
+FROM webdevops/php-dev:alpine-php7
 
 # install mhsendmail and configure it to use mailhog
 RUN apk add --no-cache musl-dev go nano curl

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,7 +1,6 @@
-FROM webdevops/php-dev:alpine-php7
+FROM webdevops/php-dev:7.3
 
 # configure postfix to use mailhog
-RUN apk add --no-cache nano curl
 RUN postconf -e "relayhost = mail:1025"
 
 # install wp cli


### PR DESCRIPTION
"requires" the PRs before.
Debian from webdevops has the advantage of wide/selectable range of php versions. 7.3 7.2 7.1. You can develop similar to your live system and Debian with sury isn't that uncommon. Yes larger container, BUT no large mhsendmail.