### PR TITLE
use faster gzip for backup

### DIFF
--- a/.utils/mysql-backup.sh
+++ b/.utils/mysql-backup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-if [ -f "./backup/mysql.sql.bz2" ]; then
+if [ -f "./backup/mysql.sql.gz" ]; then
     bash ./.utils/message.sh warning "Attention!"
-    echo "Existing backup file found: backup/mysql.sql.bz2"
+    echo "Existing backup file found: backup/mysql.sql.gz"
     echo ""
     read -e -p "Do you want to override the backup file? [N/y]: " backupOK
     [ -z "${backupOK}" ] && backupOK="N"
@@ -9,8 +9,8 @@ else
     backupOK="Yes"
 fi
 if [ "$backupOK" = "Yes" ] || [ "$backupOK" = "yes" ] || [ "$backupOK" = "y" ] || [ "$backupOK" = "y" ]; then
-    bash ./.utils/message.sh info "Creating a backup of your database in backup/mysql.sql.bz2"
+    bash ./.utils/message.sh info "Creating a backup of your database in backup/mysql.sql.gz"
     mkdir -p backup
-    docker exec -i $(docker-compose ps -q db) mysqldump -u root -ppassword --opt --single-transaction --events --databases wp --routines --comments | bzip2 > "backup/mysql.sql.bz2"
+    docker exec -i $(docker-compose ps -q db) mysqldump -u root -ppassword --opt --single-transaction --events --databases wp --routines --comments | gzip > "backup/mysql.sql.gz"
     bash ./.utils/message.sh success "Backup successful!"
 fi

--- a/.utils/mysql-restore.sh
+++ b/.utils/mysql-restore.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-if [ -f "./backup/mysql.sql.bz2" ]; then
-    bash ./.utils/message.sh info "Restoring ./backup/mysql.sql.bz2"
-    bzcat "backup/mysql.sql.bz2" | docker exec -i $(docker-compose ps -q db) mysql -u root -ppassword wp
+if [ -f "./backup/mysql.sql.gz" ]; then
+    bash ./.utils/message.sh info "Restoring ./backup/mysql.sql.gz"
+    zcat "backup/mysql.sql.gz" | docker exec -i $(docker-compose ps -q db) mysql -u root -ppassword wp
     echo "FLUSH PRIVILEGES;" | docker exec -i $(docker-compose ps -q db) mysql -u root -ppassword
     bash ./.utils/message.sh success "Restore successful!"
 else
-    bash ./.utils/message.sh info "No backup found: backup/mysql.sql.bz2"
+    bash ./.utils/message.sh info "No backup found: backup/mysql.sql.gz"
 fi


### PR DESCRIPTION
bzip is slow (search gzip bzip benchmark) and compresses a little bit better.

Examples:
**Larger environment**
Uncompressed: 1.16GB

time make mysql-backup  # bzip2
Creating a backup of your database in backup/mysql.sql.bz2
Backup successful!
make mysql-backup  98.77s user 1.62s system 98% cpu **1:43.25 total**
Size: 153 MB

time make mysql-backup # gzip
Creating a backup of your database in backup/mysql.sql.gz
Backup successful!
make mysql-backup  30.86s user 1.38s system 98% cpu **32.786 total**
Size: 205 MB

**Smaller environment**
Uncompressed 36MB

time make mysql-backup # gzip
Creating a backup of your database in backup/mysql.sql.gz
Backup successful!
make mysql-backup  0.94s user 0.08s system 79% cpu **1.288 total**
Size: 2.8MB

time make mysql-backup # bzip2
Creating a backup of your database in backup/mysql.sql.bz2
Backup successful!
make mysql-backup  5.08s user 0.11s system 96% cpu **5.349 total**
Size: 2.0MB

* Much faster because both use a single core.
* Restore is also faster.